### PR TITLE
Add build version and docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+schedules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: go
 go:
-    - "1.10.x"
-    - master
+- 1.10.x
+env:
+  global:
+  - secure: K9WAEtoTj944dQasWTi3ixNiebK0wiVqh/OldI37g4w+tddSoTvSvTq8+Dz5vUpAzDHwRrgx+EHCUOpGpntNlnEqf9GxDW9DHf8RM4l4CQVA2XqwdaonvlrZ6O0MFBriTLr0d59RSb0WdY+Gt/GmBAzuB7Q1YZmV7BS89jnzGNOzLUBAUw1RFKis0craChNOfHMy38rHFmLIphda6tmh6GqKsUo18b3yfqKhYVoIIgADtB6jLw2KGTNN7kj8bDv2DT4GCmr0oUZOE8JJh0IvizHYBK5f+PYl8vEtNiWlvR7wdfnmKKx8+KTsM55pX8puVm3X+TFE5jG8McexTmZxaEZjxcDYl0EczS5bX6LsyQuJ41x1iv0H2UwOtEKHzzft2FxTSShzxbCQUhFqZgo6Y77BaG87txtqVIaR/1XuHJeY82v/A9a8kBW6/6jKMFnCfHVRfIOeQZi8jiLgtBGLGnILiq6yDP0NGupPVSkvl/9mmlp2wlbz+BcUncAuYXM9sj2fK5DO+h+BzOFvl9iTw21mqhknCVGN/zUJS5XlqKAULVB3RNDR5fT9dUufy50bxC5YfsExSlW3vQWZz7DJIYpaud4j7M0LMwAG/x9tatZ32NV9TWDZ+/pY4eYk5VYytfhLiI0iFPKbHwzsYeRA851PoesHDhPdLN8ujeZPgXo= #DOCKER_USER
+  - secure: CXXlMRrKpksBbASW7FA9o9uFbonxl+jurRU5zfphRRCM5rEHNCG13rCCuJQlR2evAH/YDj97QOY7H8lYIUdTZGQJWcVvhK1SxLcXQZevh/+IgYAWlpVbs3G9lkz7j+4kBkCS5QRWetVnMoj9bz3zdiF2tX/+n2igNbAyhc4ElrqHKRx2pTvtLfY0npMSI08fzIwY6PvCdgkMVLFZjDzGvO1A3Su0lY/JgDieESBb61HDcMYIzTKqQGlYT92EncKjAeELyxK+szf5yNoNpziSoxu+pvFgt8j8PfBkF3bJINZnQPikbjUeXbpoVUZ39DI3xbeDb3G9ExQWzksLU/s61Yqi409QzJ0jj+hSt04AIHvKojOj2+eMugtx39tYVNeA7vgZI72xHdTKFCHB5Wp4fD627dLxIaxvJ35OUFpunVGQ2Yr7PjkiQ5/4amochlesC0lXJ5fnVijnwtR9OeCNSCmUlK7HXpPYNWJizoxVGLNyi+nHgNFmr2ZaGK1kJU2HHunXEZoqgNpjdDApSmPB20craNoo34VP0FtL7sLGHq5j5SObYMky4RQvGnRqWEeelK+Ca2tK69Jpp9o1JxEVL3t3BhCjszX/6k34JePpceAQvInlTj/bnrkauuIRVjsD5d13XzmQuBtUmeUmspi1CmhHn8xdMRlL+P6tneuEgkg= #DOCKER_PASS
 sudo: required
 services:
-    - docker
+- docker
 script:
-    - sudo apt install libzmq3-dev
-    - make setup
-    - make ci
-    - make
-matrix:
-  allow_failures:
-    - go: master
+- sudo apt install libzmq3-dev
+- make setup
+- make ci
+- make
+after_success:
+- export REPO=navitia/schedules
+- export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH
+  ; fi`
+- make docker
+- docker tag $REPO:$(make version) $REPO:$TAG
+- docker tag $REPO:$(make version) $REPO:travis-$TRAVIS_BUILD_NUMBER
+- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then docker login -u $DOCKER_USER -p $DOCKER_PASS && docker push $REPO; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ after_success:
 - make docker
 - docker tag $REPO:$(make version) $REPO:$TAG
 - docker tag $REPO:$(make version) $REPO:travis-$TRAVIS_BUILD_NUMBER
-- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then docker login -u $DOCKER_USER -p $DOCKER_PASS && docker push $REPO; fi
+- if [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASS" ]; then docker login -u $DOCKER_USER -p $DOCKER_PASS && docker push $REPO; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine as builder
+RUN apk add --update musl-dev zeromq-dev gcc git make
+WORKDIR /go/src/github.com/CanalTP/gormungandr
+ADD $PWD /go/src/github.com/CanalTP/gormungandr
+RUN make setup && make
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates zeromq
+WORKDIR /
+COPY --from=builder /go/src/github.com/CanalTP/gormungandr/schedules .
+CMD ["./schedules"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM golang:alpine as builder
 RUN apk add --update musl-dev zeromq-dev gcc git make
 WORKDIR /go/src/github.com/CanalTP/gormungandr
 ADD $PWD /go/src/github.com/CanalTP/gormungandr
-RUN make setup && make
+RUN make build
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates zeromq
+RUN apk --no-cache add libzmq
 WORKDIR /
 COPY --from=builder /go/src/github.com/CanalTP/gormungandr/schedules .
 CMD ["./schedules"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN make build
 
 FROM alpine:latest
 RUN apk --no-cache add libzmq
+USER daemon:daemon
 WORKDIR /
 COPY --from=builder /go/src/github.com/CanalTP/gormungandr/schedules .
 CMD ["./schedules"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION := $(shell git describe --tag --always)
+
 .PHONY: setup
 setup: ## Install all the build and lint dependencies
 	go get -u github.com/alecthomas/gometalinter
@@ -49,7 +51,7 @@ ci: lint test ## Run all the tests and code checks
 
 .PHONY: build
 build: ## Build a version
-	go build  -tags=jsoniter -v ./cmd/...
+	go build -ldflags "-X github.com/CanalTP/gormungandr.Version=$(VERSION)" -tags=jsoniter -v ./cmd/...
 
 .PHONY: clean
 clean: ## Remove temporary files

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,14 @@ clean: ## Remove temporary files
 install: ## install project and it's dependancies, useful for autocompletion feature
 	go install -i
 
+.PHONY: docker
+docker: ## build docker image
+	docker build -t navitia/schedules:$(VERSION) .
+
+.PHONY: version
+version: ## display version of gormungandr
+	@echo $(VERSION)
+
 # Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help
 help:

--- a/cmd/schedules/main.go
+++ b/cmd/schedules/main.go
@@ -77,17 +77,17 @@ func main() {
 
 	db, err := sql.Open("postgres", config.ConnectionString)
 	if err != nil {
-		logrus.Fatal("connection to postgres failed: ", err)
+		logger.Fatal("connection to postgres failed: ", err)
 	}
 	err = db.Ping()
 	if err != nil {
-		logrus.Fatal("connection to postgres failed: ", err)
+		logger.Fatal("connection to postgres failed: ", err)
 	}
 
 	if len(config.PprofListen) != 0 {
 		go func() {
 			logrus.Infof("pprof listening on %s", config.PprofListen)
-			logrus.Error(http.ListenAndServe(config.PprofListen, nil))
+			logger.Error(http.ListenAndServe(config.PprofListen, nil))
 		}()
 	}
 
@@ -101,6 +101,6 @@ func main() {
 	cov.GET("/*filter", schedules.NoRouteHandler(kraken))
 	err = r.Run(config.Listen)
 	if err != nil {
-		logrus.Errorf("failure to start: %+v", err)
+		logger.Errorf("failure to start: %+v", err)
 	}
 }

--- a/cmd/schedules/main.go
+++ b/cmd/schedules/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"time"
 
 	"database/sql"
@@ -19,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 )
 
 func setupRouter() *gin.Engine {
@@ -49,14 +52,26 @@ func initLog(jsonLog bool) {
 }
 
 func main() {
+	showVersion := pflag.Bool("version", false, "show version")
+	pflag.Parse()
+	if *showVersion {
+		fmt.Printf("gormungandr %s built with %s", gormungandr.Version, runtime.Version())
+		os.Exit(0)
+	}
+
+	logger := logrus.WithFields(logrus.Fields{
+		"version": gormungandr.Version,
+		"runtime": runtime.Version(),
+	})
 	config, err := schedules.GetConfig()
 	if err != nil {
-		logrus.Fatalf("failure to load configuration: %+v", err)
+		logger.Fatalf("failure to load configuration: %+v", err)
 	}
 	initLog(config.JSONLog)
-	logrus.WithFields(logrus.Fields{
+	logger = logger.WithFields(logrus.Fields{
 		"config": config,
-	}).Debug("configuration loaded")
+	})
+	logger.Info("starting schedules")
 
 	kraken := gormungandr.NewKraken("default", config.Kraken, config.Timeout)
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package gormungandr
+
+var Version = "undefined"


### PR DESCRIPTION
Build with the master of go has been disabled, it make the configuration of travis easier and make the test faster.

We use `alpine` image and not `from scratch` since we can't easily build static binary due to the dependency to libzmq.