### PR TITLE
Change base image for docker to ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM golang:alpine as builder
-RUN apk add --update musl-dev zeromq-dev gcc git make
-WORKDIR /go/src/github.com/CanalTP/gormungandr
-ADD $PWD /go/src/github.com/CanalTP/gormungandr
-RUN make build
+FROM ubuntu:16.04 as builder
+RUN apt update && apt install -y libzmq3-dev gcc git make wget pkg-config
+RUN wget https://dl.google.com/go/go1.10.2.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.10.2.linux-amd64.tar.gz
+WORKDIR /root/go/src/github.com/CanalTP/gormungandr
+ADD $PWD /root/go/src/github.com/CanalTP/gormungandr
+RUN PATH="/usr/local/go/bin:/root/go/bin:$PATH" make setup build
 
-FROM alpine:latest
-RUN apk --no-cache add libzmq curl tzdata
+FROM ubuntu:16.04
+RUN apt update && apt install -y libzmq3-dev curl tzdata
 USER daemon:daemon
 WORKDIR /
-COPY --from=builder /go/src/github.com/CanalTP/gormungandr/schedules .
+COPY --from=builder /root/go/src/github.com/CanalTP/gormungandr/schedules .
 HEALTHCHECK --interval=10s --timeout=3s CMD curl -f http://localhost:8080/status || exit 1
 CMD ["./schedules"]


### PR DESCRIPTION
Image based on debian 9 or alpine have some kind of bug that make gormun
crash in libzmq. It might be caused by the version of libzmq, or another
dependency. I did not easily reproduce this issue locally with docker, it
only appear in production...

For now we will use a configuration known to work while we analyse what
happens in these environments