### PR TITLE
POC Migration to Echo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,6 +56,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/dgrijalva/jwt-go"
+  packages = ["."]
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/docker/docker"
   packages = [
@@ -118,12 +124,6 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/gin-contrib/cors"
-  packages = ["."]
-  revision = "cf4846e6a636a76237a28d9286f163c132e841bc"
-  version = "v1.2"
-
-[[projects]]
   branch = "fix-host"
   name = "github.com/gin-contrib/location"
   packages = ["."]
@@ -135,12 +135,6 @@
   name = "github.com/gin-contrib/sse"
   packages = ["."]
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/gin-gonic/contrib"
-  packages = ["ginrus"]
-  revision = "9b830a15f6abcf9e160f47ee01fc00691cc1981a"
 
 [[projects]]
   branch = "master"
@@ -189,6 +183,26 @@
   version = "1.1.3"
 
 [[projects]]
+  name = "github.com/labstack/echo"
+  packages = [
+    ".",
+    "middleware"
+  ]
+  revision = "6d227dfea4d2e52cb76856120b3c17f758139b4e"
+  version = "3.3.5"
+
+[[projects]]
+  name = "github.com/labstack/gommon"
+  packages = [
+    "bytes",
+    "color",
+    "log",
+    "random"
+  ]
+  revision = "588f4e8bddc6cb45c27b448e925c7fd6a5545434"
+  version = "0.2.5"
+
+[[projects]]
   branch = "master"
   name = "github.com/lib/pq"
   packages = [
@@ -202,6 +216,12 @@
   packages = ["."]
   revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
   version = "v1.7.6"
+
+[[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
@@ -232,21 +252,6 @@
   packages = ["."]
   revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
   version = "1.0.0"
-
-[[projects]]
-  name = "github.com/newrelic/go-agent"
-  packages = [
-    ".",
-    "_integrations/nrgin/v1",
-    "internal",
-    "internal/cat",
-    "internal/jsonx",
-    "internal/logger",
-    "internal/sysinfo",
-    "internal/utilization"
-  ]
-  revision = "f5bce3387232559bcbe6a5f8227c4bf508dac1ba"
-  version = "v1.11.0"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"
@@ -434,8 +439,24 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/valyala/bytebufferpool"
+  packages = ["."]
+  revision = "e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/valyala/fasttemplate"
+  packages = ["."]
+  revision = "dcecefd839c4193db0d35b88ec65b4c12d360ab0"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "acme",
+    "acme/autocert",
+    "ssh/terminal"
+  ]
   revision = "2c241ca3045ddc354463c376a9515d9f1f1390a4"
 
 [[projects]]
@@ -496,6 +517,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5d620e992e0b7e5e5d807914cbf18edb89b5d5692b08304e3f6ae0d69ab6a380"
+  inputs-digest = "b4f22a141d512c2c26a67e8a55319744788fba2474541b80d4d8b6098bc74f80"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/auth/stat.go
+++ b/auth/stat.go
@@ -6,8 +6,8 @@ import (
 	"github.com/CanalTP/gonavitia"
 	"github.com/CanalTP/gonavitia/pbnavitia"
 	"github.com/CanalTP/gormungandr/internal/schedules"
-	"github.com/gin-gonic/gin"
 	"github.com/golang/protobuf/proto"
+	"github.com/labstack/echo"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rafaeljesus/rabbus"
@@ -75,7 +75,7 @@ func (s *StatPublisher) publish(stat pbnavitia.StatRequest) error {
 	}
 }
 
-func buildStatForRouteSchedule(request schedules.RouteScheduleRequest, response gonavitia.RouteScheduleResponse, c gin.Context) pbnavitia.StatRequest {
+func buildStatForRouteSchedule(request schedules.RouteScheduleRequest, response gonavitia.RouteScheduleResponse, c echo.Context) pbnavitia.StatRequest {
 	return pbnavitia.StatRequest{
 		RequestDate:     proto.Uint64(uint64(time.Now().Unix())),
 		Api:             proto.String("v1.route_schedules"),
@@ -87,9 +87,9 @@ func buildStatForRouteSchedule(request schedules.RouteScheduleRequest, response 
 		EndPointName:    &request.User.EndPointName,
 		ApplicationId:   proto.Int32(-1), //same as jormun
 		RequestDuration: proto.Int32(0),  //TODO
-		Path:            proto.String(c.Request.URL.Path),
-		Host:            proto.String(c.Request.URL.Host),
-		Client:          proto.String(c.ClientIP()),
+		Path:            proto.String(c.Request().URL.Path),
+		Host:            proto.String(c.Request().URL.Host),
+		Client:          proto.String(c.RealIP()),
 		ResponseSize:    proto.Int32(0), //always been wrong in jormun...
 		InfoResponse:    buildStatInfoResponse(response.Pagination),
 		Coverages:       []*pbnavitia.StatCoverage{{RegionId: &request.Coverage}},
@@ -106,7 +106,7 @@ func buildStatInfoResponse(pagination *gonavitia.Pagination) *pbnavitia.StatInfo
 }
 
 func (s *StatPublisher) PublishRouteSchedule(request schedules.RouteScheduleRequest,
-	response gonavitia.RouteScheduleResponse, c gin.Context) error {
+	response gonavitia.RouteScheduleResponse, c echo.Context) error {
 
 	if s == nil { //if nil is passed by interface we don't want to panic
 		return nil

--- a/cmd/schedules/main.go
+++ b/cmd/schedules/main.go
@@ -10,74 +10,79 @@ import (
 	"syscall"
 	"time"
 
-	"database/sql"
+	//"database/sql"
 
 	_ "net/http/pprof"
 
 	"github.com/CanalTP/gormungandr"
 	"github.com/CanalTP/gormungandr/auth"
 	"github.com/CanalTP/gormungandr/internal/schedules"
-	cache "github.com/patrickmn/go-cache"
-	"github.com/rafaeljesus/rabbus"
+	//cache "github.com/patrickmn/go-cache"
+	//"github.com/rafaeljesus/rabbus"
 
-	"github.com/gin-contrib/cors"
-	"github.com/gin-contrib/location"
-	"github.com/gin-gonic/contrib/ginrus"
-	"github.com/gin-gonic/gin"
-	"github.com/newrelic/go-agent"
-	"github.com/newrelic/go-agent/_integrations/nrgin/v1"
+	//"github.com/gin-contrib/cors"
+	//"github.com/gin-contrib/location"
+	//"github.com/gin-gonic/contrib/ginrus"
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
+	//"github.com/newrelic/go-agent"
+	//"github.com/newrelic/go-agent/_integrations/nrgin/v1"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
-func setupRouter(config schedules.Config) *gin.Engine {
-	r := gin.New()
-	r.Use(ginrus.Ginrus(logrus.StandardLogger(), time.RFC3339, false))
-	r.Use(gormungandr.InstrumentGin())
+func setupRouter(config schedules.Config) *echo.Echo {
+	e := echo.New()
+	//r.Use(ginrus.Ginrus(logrus.StandardLogger(), time.RFC3339, false))
+	e.Use(middleware.Logger())
+	e.Use(middleware.Recover())
+	e.Use(gormungandr.Instrument)
 	// Recovery middleware recovers from any panics and writes a 500 if there was one.
-	r.Use(gormungandr.Recovery())
+	//r.Use(gormungandr.Recovery())
 
-	r.Use(cors.New(cors.Config{
-		AllowAllOrigins:  true,
-		AllowHeaders:     []string{"Access-Control-Request-Headers", "Authorization"},
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins:     []string{"*"},
+		AllowHeaders:     []string{echo.HeaderAuthorization, echo.HeaderAccessControlRequestHeaders},
 		AllowCredentials: true,
-		MaxAge:           12 * time.Hour,
+		MaxAge:           int((12 * time.Hour).Seconds()),
 	}))
-	r.Use(location.New(location.Config{
-		Scheme: "http",
-		Host:   "navitia.io",
-	}))
+	/*
 
-	if len(config.NewRelicLicense) > 0 {
-		nrConfig := newrelic.NewConfig(config.NewRelicAppName, config.NewRelicLicense)
-		app, err := newrelic.NewApplication(nrConfig)
-		if err != nil {
-			logrus.Fatalf("Impossible to initialize newrelic: %+v", err)
+		if len(config.NewRelicLicense) > 0 {
+			nrConfig := newrelic.NewConfig(config.NewRelicAppName, config.NewRelicLicense)
+			app, err := newrelic.NewApplication(nrConfig)
+			if err != nil {
+				logrus.Fatalf("Impossible to initialize newrelic: %+v", err)
+			}
+			r.Use(nrgin.Middleware(app))
 		}
-		r.Use(nrgin.Middleware(app))
-	}
+	*/
 
-	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
 
-	r.GET("/", Index)
-	r.GET("/status", Status)
+	e.GET("/", Index)
+	e.GET("/status", Status)
 
-	return r
+	return e
 }
 
-func Index(c *gin.Context) {
+func Index(c echo.Context) error {
 	//this is temporary, but our LB except this to work...
-	c.JSON(200, gin.H{
-		"versions": "",
-	})
+	return c.JSON(http.StatusOK, struct {
+		Versions string `json:"version"`
+	}{})
 }
 
-func Status(c *gin.Context) {
-	c.JSON(200, gin.H{
-		"status":  "ok",
-		"version": gormungandr.Version,
-		"runtime": runtime.Version(),
+func Status(c echo.Context) error {
+	return c.JSON(http.StatusOK, struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+		Runtime string `json:"runtime"`
+	}{
+		Status:  "ok",
+		Version: gormungandr.Version,
+		Runtime: runtime.Version(),
 	})
 }
 
@@ -117,77 +122,75 @@ func main() {
 	logger.Info("starting schedules")
 
 	kraken := gormungandr.NewKraken("default", config.Kraken, config.Timeout)
-	router := setupRouter(config)
-	cov := router.Group("/v1/coverage/:coverage")
+	echo := setupRouter(config)
 
-	if !config.SkipAuth {
-		//disable database if authentication isn't used
-		var (
-			db        *sql.DB
-			authCache *cache.Cache
-		)
-		db, err = sql.Open("postgresInstrumented", config.ConnectionString)
-		db.SetMaxOpenConns(config.MaxPostgresqlConnection)
-		if err != nil {
-			logger.Fatal("connection to postgres failed: ", err)
+	cov := echo.Group("/v1/coverage/:coverage")
+	/*
+		if !config.SkipAuth {
+			//disable database if authentication isn't used
+			var (
+				db        *sql.DB
+				authCache *cache.Cache
+			)
+			db, err = sql.Open("postgresInstrumented", config.ConnectionString)
+			db.SetMaxOpenConns(config.MaxPostgresqlConnection)
+			if err != nil {
+				logger.Fatal("connection to postgres failed: ", err)
+			}
+			err = db.Ping()
+			if err != nil {
+				logger.Fatal("connection to postgres failed: ", err)
+			}
+			if config.AuthCacheTimeout.Seconds() > 0 {
+				logger.Info("Activate authentication cache")
+				authCache = cache.New(config.AuthCacheTimeout, config.AuthCacheTimeout*2)
+			}
+
+			cov.Use(auth.AuthenticationMiddleware(db, authCache))
 		}
-		err = db.Ping()
-		if err != nil {
-			logger.Fatal("connection to postgres failed: ", err)
+
+		if len(config.PprofListen) != 0 {
+			go func() {
+				logrus.Infof("pprof listening on %s", config.PprofListen)
+				logger.Error(http.ListenAndServe(config.PprofListen, nil))
+			}()
 		}
-		if config.AuthCacheTimeout.Seconds() > 0 {
-			logger.Info("Activate authentication cache")
-			authCache = cache.New(config.AuthCacheTimeout, config.AuthCacheTimeout*2)
+
+		var statPublisher *auth.StatPublisher
+		if !config.SkipStats {
+			var rmq *rabbus.Rabbus
+			rmq, err = rabbus.New(
+				config.RabbitmqDsn,
+				rabbus.Durable(true),
+				rabbus.Attempts(3),
+				rabbus.Sleep(time.Second*2),
+			)
+			if err != nil {
+				logrus.Fatal("failure while connecting to rabbitmq ", err)
+			}
+			defer func(rmq *rabbus.Rabbus) {
+				if err = rmq.Close(); err != nil {
+					logrus.Fatal("failure while closing rabbitmq connection ", err)
+				}
+			}(rmq)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			go func() {
+				if err = rmq.Run(ctx); err != nil && err != context.Canceled {
+					logrus.Errorf("rabbus.run ended with error: %+v", err)
+				}
+			}()
+			statPublisher = auth.NewStatPublisher(rmq, config.StatsExchange, 2*time.Second)
 		}
-
-		cov.Use(auth.AuthenticationMiddleware(db, authCache))
-	}
-
-	if len(config.PprofListen) != 0 {
-		go func() {
-			logrus.Infof("pprof listening on %s", config.PprofListen)
-			logger.Error(http.ListenAndServe(config.PprofListen, nil))
-		}()
-	}
-
+	*/
 	var statPublisher *auth.StatPublisher
-	if !config.SkipStats {
-		var rmq *rabbus.Rabbus
-		rmq, err = rabbus.New(
-			config.RabbitmqDsn,
-			rabbus.Durable(true),
-			rabbus.Attempts(3),
-			rabbus.Sleep(time.Second*2),
-		)
-		if err != nil {
-			logrus.Fatal("failure while connecting to rabbitmq ", err)
-		}
-		defer func(rmq *rabbus.Rabbus) {
-			if err = rmq.Close(); err != nil {
-				logrus.Fatal("failure while closing rabbitmq connection ", err)
-			}
-		}(rmq)
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	cov.GET("/*", schedules.NoRouteHandler(kraken, statPublisher))
 
-		go func() {
-			if err = rmq.Run(ctx); err != nil && err != context.Canceled {
-				logrus.Errorf("rabbus.run ended with error: %+v", err)
-			}
-		}()
-		statPublisher = auth.NewStatPublisher(rmq, config.StatsExchange, 2*time.Second)
-	}
-
-	cov.GET("/*filter", schedules.NoRouteHandler(kraken, statPublisher))
-
-	srv := &http.Server{
-		Addr:    config.Listen,
-		Handler: router,
-	}
 	go func() {
 		// service connections
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Fatalf("listen: %s", err)
+		if err := echo.Start(config.Listen); err != nil {
+			logger.Info("shutting down the server")
 		}
 	}()
 
@@ -200,7 +203,7 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := srv.Shutdown(ctx); err != nil {
+	if err := echo.Shutdown(ctx); err != nil {
 		logrus.Fatal("Server Shutdown:", err)
 	}
 	logrus.Info("Server exiting")


### PR DESCRIPTION
Usage of echo in place of gin as framework.
pro:
  - Echo seem's to be more maintened than gin, and have a different documentation, maybe not better but easier to read.
  - Echo is less opinionated on the binder as one is provided by default but it can be replaced easily.
  - Error handling is far better
  - streaming of the response is possible (not sure about gin)
  - `echo.Context` can be extended

cons:
  - I didn't found a way to get the name of an handler, so currently prometheus can't differentiate between handler, however it's possible to give a name to a route that I didn't found way to get anywhere.