### PR TITLE
Handle wrongly formatted basic auth

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"database/sql"
+	"encoding/base64"
+	"strings"
 	"time"
 
 	"github.com/CanalTP/gormungandr"
@@ -15,6 +17,15 @@ func getToken(c *gin.Context) string {
 	if ok {
 		return username
 	} else if authorization := c.GetHeader("Authorization"); len(authorization) > 0 {
+		if strings.HasPrefix(strings.ToLower(authorization), "basic ") {
+			//this is basic authentication with the missing ":" at the end
+			//it isn't valid per the standard but jormungandr understand it, so...
+			value, err := base64.StdEncoding.DecodeString(authorization[6:])
+			if err != nil {
+				return ""
+			}
+			return string(value)
+		}
 		return authorization
 	} else {
 		return c.Query("key")


### PR DESCRIPTION
Even if the [RFC](https://tools.ietf.org/html/rfc2617#section-2) specify
that the ":" is required jormungandr handle the case were it's missing,
so to be on the safe side gormungandr has to handle it too.